### PR TITLE
Added endpoint to to fetch modules given the auth header. Changed JWT token property - HTTPOnly(false)

### DIFF
--- a/src/main/java/com/tutoring/Tutorverse/Controller/AuthController.java
+++ b/src/main/java/com/tutoring/Tutorverse/Controller/AuthController.java
@@ -111,7 +111,7 @@ public class AuthController {
 
         // Store JWT in HTTP-only cookie for session management (same as OAuth2)
         Cookie jwtCookie = new Cookie("jwt_token", token);
-        jwtCookie.setHttpOnly(true);
+        jwtCookie.setHttpOnly(false);
         jwtCookie.setSecure(false); // Set to true in production with HTTPS
         jwtCookie.setPath("/");
         jwtCookie.setMaxAge(86400); // 1 day
@@ -173,7 +173,7 @@ public class AuthController {
 
         // Store JWT in HTTP-only cookie for session management (same as OAuth2)
         Cookie jwtCookie = new Cookie("jwt_token", token);
-        jwtCookie.setHttpOnly(true);
+        jwtCookie.setHttpOnly(false);
         jwtCookie.setSecure(false); // Set to true in production with HTTPS
         jwtCookie.setPath("/");
         jwtCookie.setMaxAge(86400); // 1 day
@@ -217,7 +217,7 @@ public class AuthController {
     @GetMapping("/api/logout")
     public ResponseEntity<?> logout(HttpServletResponse response) {
         Cookie jwtCookie = new Cookie("jwt_token", null);
-        jwtCookie.setHttpOnly(true);
+        jwtCookie.setHttpOnly(false);
         jwtCookie.setSecure(false);
         jwtCookie.setPath("/");
         jwtCookie.setMaxAge(0);

--- a/src/main/java/com/tutoring/Tutorverse/Controller/ModulesController.java
+++ b/src/main/java/com/tutoring/Tutorverse/Controller/ModulesController.java
@@ -108,9 +108,11 @@ public class ModulesController {
         return user;
     }
 
-    @GetMapping("/tutor/{id}")
-    public ResponseEntity<List<ModuelsDto>> getModulesByTutorId(@PathVariable UUID id) {
-        List<ModuelsDto> modules = modulesService.getModulesByTutorId(id);
+    @GetMapping("/tutor")
+    public ResponseEntity<List<ModuelsDto>> getModulesByTutorId(@RequestHeader(value = "Authorization", required = false) String authHeader) {
+        User tutor = requireTutor(authHeader);
+        List<ModuelsDto> modules = modulesService.getModulesByTutorId(tutor.getId());
+        System.out.println(modules);
         return ResponseEntity.ok(modules);
     }
 }

--- a/src/main/java/com/tutoring/Tutorverse/Services/Oauth2SuccessHandlerServices.java
+++ b/src/main/java/com/tutoring/Tutorverse/Services/Oauth2SuccessHandlerServices.java
@@ -84,7 +84,7 @@ public class Oauth2SuccessHandlerServices implements AuthenticationSuccessHandle
 
             // Store JWT in HTTP-only cookie for session management
             Cookie jwtCookie = new Cookie("jwt_token", jwttoken);
-            jwtCookie.setHttpOnly(true); // Prevents JavaScript access (XSS protection)
+            jwtCookie.setHttpOnly(false); // Prevents JavaScript access (XSS protection)
             jwtCookie.setSecure(false); // Set to true in production with HTTPS
             jwtCookie.setPath("/"); // Available for entire application
             jwtCookie.setMaxAge(86400); // 1 day (same as JWT expiration)

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,10 +1,10 @@
 spring.application.name=Tutorverse
 
-spring.datasource.url = jdbc:postgresql://129.159.229.155:5431/otp_db
+spring.datasource.url = jdbc:postgresql://129.159.229.155:5431/testiran
 spring.datasource.username=group29
 spring.datasource.password=project25
 
-#spring.datasource.url=jdbc:postgresql://localhost:5432/tutorverse
+#spring.datasource.url=jdbc:postgresql://localhost:5432/testiran
 #spring.datasource.username=postgres
 #spring.datasource.password=1234
 #spring.datasource.driver-class-name=org.postgresql.Driver


### PR DESCRIPTION
**Feature Added**

Added new endpoint /api/modules/tutor that allows tutors to retrieve all modules they've created
Implemented authentication verification to ensure only authorized tutors can access their modules
Changed HTTPonly(false) for JWT tokens. Problems came up accessing the JWT from frontend

**Implementation Details**

Created a GET endpoint in ModulesController that retrieves modules based on the authenticated tutor's ID
Utilizes the existing requireTutor method to verify user authentication and role permissions
Leverages the ModulesService.getModulesByTutorId() method to fetch relevant data
Returns a list of module DTOs with HTTP 200 OK status

**Security Considerations**

Endpoint enforces tutor role permission checks
JWT token validation ensures only authenticated users can access their data
No tutor can access modules created by another tutor